### PR TITLE
Accessbility improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2018-03-10
+### Added
+- Pass all other props supplied to `<Modal />` to the container component. This allow you to set `aria-labelledby` and `aria-describedby`, for example
+- When supplying an `appId` prop, that element is set to `aria-hidden="true"` when Modal is open
+### Changed
+- `modalComponent` and `backdropComponent` are set in `render()` so they can change dynamically
+### Fixed
+- Side effects for opening the Modal are now run on `componentWillMount()`, if Modal should be open when mounted.
+
 ## [1.0.3] - 2018-03-10
 ### Changed
 - Target current node version

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 
 import Modal from '../src';
 
@@ -56,5 +56,12 @@ describe('Modal', () => {
 
     expect(onOpen).toHaveBeenCalledTimes(1);
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('Should pass props', () => {
+    const wrapper = mount(<Modal foo="bar" />);
+    const deepModal = wrapper.children().instance().props.children.props.children.props.children;
+    expect(deepModal.props.foo).toBeDefined();
+    expect(deepModal.props.foo).toEqual('bar');
   });
 });

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -5,6 +5,7 @@ import focusLock from 'dom-focus-lock/umd';
 import noScroll from 'no-scroll';
 
 import hasDom from '../utils/has-dom';
+import setAriaHidden from '../utils/aria-hidden';
 import Portal from './Portal';
 import { container, backdrop } from '../styles';
 import FallbackBackdrop from './Backdrop';
@@ -12,6 +13,7 @@ import Overscroll from './Overscroll';
 import FallbackContainer from './Container';
 
 type Props = {
+  appId?: string,
   backdropComponent: any,
   children?: any,
   closeOnEsc: boolean,
@@ -59,6 +61,12 @@ export default class Modal extends Component<Props, State> {
     `;
   }
 
+  componentDidMount = () => {
+    if (this.state.open) {
+      this.openModalSideEffects();
+    }
+  };
+
   componentWillReceiveProps = ({ open }: Props) => {
     if (open !== this.state.open)
       this.setState({ open }, () => {
@@ -71,7 +79,7 @@ export default class Modal extends Component<Props, State> {
   };
 
   componentWillUnmount = () => {
-    this.removeEventListeners();
+    this.closeModalSideEffects();
   };
 
   callback = (callback?: any => any) => {
@@ -80,23 +88,31 @@ export default class Modal extends Component<Props, State> {
     }
   };
 
-  openModal = () => {
+  openModalSideEffects = () => {
     if (hasDom()) {
       focusLock.on(this.container);
       noScroll.on();
       this.addEventListeners();
+      setAriaHidden.on(this.props.appId);
     }
+  };
 
+  openModal = () => {
+    this.openModalSideEffects();
     this.setState({ open: true }, this.callback(this.props.onOpen));
   };
 
-  closeModal = () => {
+  closeModalSideEffects = () => {
     if (hasDom()) {
       focusLock.off(this.container);
       noScroll.off();
       this.removeEventListeners();
+      setAriaHidden.off(this.props.appId);
     }
+  };
 
+  closeModal = () => {
+    this.closeModalSideEffects();
     this.setState({ open: false }, this.callback(this.props.onClose));
   };
 

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -130,18 +130,31 @@ export default class Modal extends Component<Props, State> {
     this.props.children !== nextProps.children;
 
   render = () => {
-    const { children, targetId } = this.props;
-    const { open } = this.state;
+    /* eslint-disable no-unused-vars */
+    const {
+      appId,
+      backdropComponent,
+      children,
+      closeOnEsc,
+      closeOnOutsideClick,
+      modalComponent,
+      onClose,
+      onOpen,
+      open,
+      targetId,
+      ...rest
+    } = this.props;
+    /* eslint-enable no-unused-vars */
 
     const Backdrop = this.Backdrop;
     const Container = this.Container;
 
     return (
       <Portal targetId={targetId}>
-        {open && (
+        {this.state.open && (
           <Backdrop>
             <Overscroll>
-              <Container role="dialog" innerRef={r => (this.container = r)}>
+              <Container aria-modal="true" role="dialog" innerRef={r => (this.container = r)} {...rest}>
                 {children}
               </Container>
             </Overscroll>

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -39,26 +39,13 @@ export default class Modal extends Component<Props, State> {
   };
 
   container: ?Element;
-  Backdrop: any;
-  Overscroll: any;
-  Container: any;
 
   constructor(props: Props) {
     super(props);
 
-    const { backdropComponent: Backdrop, modalComponent: Container, open } = props;
-
     this.state = {
-      open,
+      open: props.open,
     };
-
-    this.Backdrop = Backdrop.extend`
-      ${backdrop};
-    `;
-
-    this.Container = Container.extend`
-      ${container};
-    `;
   }
 
   componentDidMount = () => {
@@ -143,7 +130,9 @@ export default class Modal extends Component<Props, State> {
   shouldComponentUpdate = (nextProps: Props, nextState: State) =>
     this.state.open !== nextState.open ||
     this.props.open !== nextProps.open ||
-    this.props.children !== nextProps.children;
+    this.props.children !== nextProps.children ||
+    this.props.modalComponent !== nextProps.modalComponent ||
+    this.props.backdropComponent !== nextProps.backdropComponent;
 
   render = () => {
     /* eslint-disable no-unused-vars */
@@ -162,8 +151,13 @@ export default class Modal extends Component<Props, State> {
     } = this.props;
     /* eslint-enable no-unused-vars */
 
-    const Backdrop = this.Backdrop;
-    const Container = this.Container;
+    const Backdrop = backdropComponent.extend`
+      ${backdrop};
+    `;
+
+    const Container = modalComponent.extend`
+      ${container};
+    `;
 
     return (
       <Portal targetId={targetId}>

--- a/src/utils/aria-hidden.js
+++ b/src/utils/aria-hidden.js
@@ -1,0 +1,15 @@
+const setAriaHidden = (boolean, id) => {
+  if (!id) return;
+  const element = document.getElementById(id);
+  if (!element) return;
+  boolean ? element.setAttribute('aria-hidden', 'true') : element.removeAttribute('aria-hidden');
+};
+
+const on = id => setAriaHidden(true, id);
+
+const off = id => setAriaHidden(false, id);
+
+export default {
+  on,
+  off,
+};

--- a/stories/01-default.js
+++ b/stories/01-default.js
@@ -5,7 +5,7 @@ import Modal from '../src';
 
 storiesOf('portal-modal', module).add('Default stateless Modal', () => (
   <Fragment>
-    <Modal>
+    <Modal appId="root">
       <p>This text is rendered in a Modal</p>
     </Modal>
   </Fragment>

--- a/stories/02-stateful.js
+++ b/stories/02-stateful.js
@@ -23,6 +23,7 @@ class StateContainer extends Component {
     <Fragment>
       <button onClick={this.handleOpen}>Open Modal</button>
       <Modal
+        appId="root"
         closeOnEsc={true}
         closeOnOutsideClick={true}
         onClose={this.handleClose}

--- a/stories/02-stateful.js
+++ b/stories/02-stateful.js
@@ -28,7 +28,6 @@ class StateContainer extends Component {
         onClose={this.handleClose}
         onOpen={this.handleOpen}
         open={this.state.open}
-        showClose={true}
       >
         {this.props.children}
       </Modal>


### PR DESCRIPTION
This PR continues on PR https://github.com/iiroj/styled-modal/pull/4 by adding improvements to accessibility of `<Modal />`:

* Allow hiding of the React app with `aria-hidden="true"` when Modal is open by supplying an `appId` prop.
* Pass all other props to the modal container component, allowing one to set `aria-labelledby` and `aria-describedby`, for example

It also fixes some incorrect behaviour:
* Side effects for opening the Modal were not run when the Modal mounted as open.

Lastly, there's an improvement on styling:
* The components for backdrop and modal container are now evaluated in the `render` function and can thus change their styles on-the-fly.